### PR TITLE
Add Helm chart for deployment-tracker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,20 @@ jobs:
       - name: Test
         run: |
           make integration-test
+
+  helm-lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+      - name: Lint chart
+        run: helm lint deploy/charts/deployment-tracker --set config.org=test --set config.logicalEnvironment=test --set config.cluster=test
+      - name: Validate chart rendering
+        run: helm template test deploy/charts/deployment-tracker --set config.org=test --set config.logicalEnvironment=test --set config.cluster=test > /dev/null

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   release:
     name: Build and Release OCI Image
@@ -53,6 +57,28 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-name: ghcr.io/github/artifact-attestations-opa-provider
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Update chart version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          sed -i "s/^version:.*/version: ${VERSION}/" deploy/charts/deployment-tracker/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" deploy/charts/deployment-tracker/Chart.yaml
+
+      - name: Package Helm chart
+        run: helm package deploy/charts/deployment-tracker
+
+      - name: Log in to GHCR for Helm
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+          helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push Helm chart to GHCR
+        run: |
+          helm push deployment-tracker-*.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/deploy/charts/deployment-tracker/.helmignore
+++ b/deploy/charts/deployment-tracker/.helmignore
@@ -1,0 +1,13 @@
+# Patterns to ignore when building packages.
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.git
+.gitignore
+.project
+.idea
+*.tmproj
+.vscode

--- a/deploy/charts/deployment-tracker/Chart.yaml
+++ b/deploy/charts/deployment-tracker/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: deployment-tracker
 description: A Kubernetes controller that monitors pod lifecycles and uploads deployment records to GitHub's artifact metadata API
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.0
+appVersion: "0.0.0"
 kubeVersion: ">= 1.19.0-0"
 keywords:
   - kubernetes

--- a/deploy/charts/deployment-tracker/Chart.yaml
+++ b/deploy/charts/deployment-tracker/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: deployment-tracker
+description: A Kubernetes controller that monitors pod lifecycles and uploads deployment records to GitHub's artifact metadata API
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">= 1.19.0-0"
+keywords:
+  - kubernetes
+  - deployment-tracker
+  - github
+  - artifact-attestations
+  - supply-chain-security
+home: https://github.com/github/deployment-tracker
+maintainers:
+  - name: GitHub Package Security
+    url: https://github.com/github

--- a/deploy/charts/deployment-tracker/README.md
+++ b/deploy/charts/deployment-tracker/README.md
@@ -1,0 +1,173 @@
+# deployment-tracker Helm Chart
+
+A Helm chart for deploying the deployment-tracker Kubernetes controller, which
+monitors pod lifecycles and uploads deployment records to GitHub's artifact
+metadata API.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.8+
+- A GitHub organization with
+  [Artifact Attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations)
+  enabled
+- An API token or GitHub App for authentication
+
+## Installation
+
+### Install from OCI registry
+
+```bash
+helm install deployment-tracker \
+  oci://ghcr.io/github/charts/deployment-tracker \
+  --namespace deployment-tracker \
+  --create-namespace \
+  --set config.org=my-org \
+  --set config.logicalEnvironment=production \
+  --set config.cluster=my-cluster \
+  --set auth.apiTokenSecret=my-api-token-secret
+```
+
+### Install from local source
+
+```bash
+helm install deployment-tracker ./deploy/charts/deployment-tracker \
+  --namespace deployment-tracker \
+  --create-namespace \
+  -f my-values.yaml
+```
+
+## Required Values
+
+The following values **must** be set for the controller to function:
+
+| Value | Description |
+|-------|-------------|
+| `config.org` | GitHub organization name |
+| `config.logicalEnvironment` | Logical environment name (e.g., `production`, `staging`) |
+| `config.cluster` | Kubernetes cluster name |
+
+At least one authentication method must be configured (see
+[Authentication](#authentication)).
+
+## Configuration
+
+### Controller Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `config.org` | GitHub organization name | `""` (required) |
+| `config.logicalEnvironment` | Logical environment name | `""` (required) |
+| `config.cluster` | Cluster name | `""` (required) |
+| `config.physicalEnvironment` | Physical environment name | `""` |
+| `config.baseUrl` | API base URL | `api.github.com` |
+| `config.dnTemplate` | Deployment name template | `{{namespace}}/{{deploymentName}}/{{containerName}}` |
+| `config.namespace` | Namespace to monitor (empty for all) | `""` |
+| `config.excludeNamespaces` | Namespaces to exclude (comma-separated) | `""` |
+| `config.workers` | Number of worker goroutines | `2` |
+| `config.metricsPort` | Port for Prometheus metrics | `9090` |
+
+### Image Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Container image repository | `ghcr.io/github/deployment-tracker` |
+| `image.tag` | Container image tag | Chart `appVersion` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+
+### Authentication
+
+The controller supports two authentication methods: API token and GitHub App.
+
+#### API Token
+
+```yaml
+# Option 1: Inline token (not recommended for production)
+auth:
+  apiToken: "ghp_xxxxxxxxxxxx"
+
+# Option 2: Reference to an existing Secret (recommended)
+auth:
+  apiTokenSecret: "my-api-token-secret"
+```
+
+When using `apiTokenSecret`, the Secret must have a key named `token`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-api-token-secret
+type: Opaque
+stringData:
+  token: "ghp_xxxxxxxxxxxx"
+```
+
+#### GitHub App
+
+```yaml
+# Option 1: Inline private key
+auth:
+  githubApp:
+    appId: "12345"
+    installId: "67890"
+    privateKey: "<base64-encoded-private-key>"
+
+# Option 2: Reference to an existing Secret (recommended)
+auth:
+  githubApp:
+    appId: "12345"
+    installId: "67890"
+    privateKeySecret: "my-github-app-secret"
+```
+
+When using `privateKeySecret`, the Secret must have a key named `private-key`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-github-app-secret
+type: Opaque
+stringData:
+  private-key: "<base64-encoded-private-key>"
+```
+
+### Resources and Security
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of controller replicas | `1` |
+| `resources.requests.cpu` | CPU request | `100m` |
+| `resources.requests.memory` | Memory request | `1024Mi` |
+| `resources.limits.cpu` | CPU limit | `200m` |
+| `resources.limits.memory` | Memory limit | `2048Mi` |
+| `securityContext` | Container security context | Hardened (see values.yaml) |
+| `readinessProbe` | Readiness probe configuration | HTTP GET /metrics:9090 |
+| `lifecycle` | Lifecycle hooks | preStop sleep 5s |
+
+### Service and Networking
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `service.enabled` | Create a Service for metrics | `true` |
+| `service.type` | Service type | `ClusterIP` |
+| `service.port` | Service port | `9090` |
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Tolerations | `[]` |
+| `affinity` | Affinity rules | `{}` |
+
+### Service Account
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Create a ServiceAccount | `true` |
+| `serviceAccount.name` | ServiceAccount name | Generated from fullname |
+| `serviceAccount.annotations` | ServiceAccount annotations | `{}` |
+
+## Uninstalling
+
+```bash
+helm uninstall deployment-tracker -n deployment-tracker
+```

--- a/deploy/charts/deployment-tracker/templates/NOTES.txt
+++ b/deploy/charts/deployment-tracker/templates/NOTES.txt
@@ -1,10 +1,5 @@
 deployment-tracker has been installed.
 
-{{- if not .Values.config.org }}
-
-WARNING: config.org is not set. The controller requires a GitHub organization name.
-{{- end }}
-
 1. Check the deployment status:
 
    kubectl get deployment {{ include "deployment-tracker.fullname" . }} -n {{ .Release.Namespace }}

--- a/deploy/charts/deployment-tracker/templates/NOTES.txt
+++ b/deploy/charts/deployment-tracker/templates/NOTES.txt
@@ -1,0 +1,26 @@
+deployment-tracker has been installed.
+
+{{- if not .Values.config.org }}
+
+WARNING: config.org is not set. The controller requires a GitHub organization name.
+{{- end }}
+
+1. Check the deployment status:
+
+   kubectl get deployment {{ include "deployment-tracker.fullname" . }} -n {{ .Release.Namespace }}
+
+2. Check the controller pods:
+
+   kubectl get pods -n {{ .Release.Namespace }} -l "{{ include "deployment-tracker.selectorLabels" . | replace "\n" "," }}"
+
+3. View controller logs:
+
+   kubectl logs -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "deployment-tracker.name" . }}" -f
+
+{{- if .Values.service.enabled }}
+
+4. Access Prometheus metrics:
+
+   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "deployment-tracker.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+   curl http://localhost:{{ .Values.service.port }}/metrics
+{{- end }}

--- a/deploy/charts/deployment-tracker/templates/_helpers.tpl
+++ b/deploy/charts/deployment-tracker/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "deployment-tracker.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "deployment-tracker.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "deployment-tracker.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "deployment-tracker.labels" -}}
+helm.sh/chart: {{ include "deployment-tracker.chart" . }}
+{{ include "deployment-tracker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "deployment-tracker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "deployment-tracker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "deployment-tracker.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "deployment-tracker.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/deployment-tracker/templates/_helpers.tpl
+++ b/deploy/charts/deployment-tracker/templates/_helpers.tpl
@@ -55,6 +55,6 @@ Create the name of the service account to use.
 {{- if .Values.serviceAccount.create }}
 {{- default (include "deployment-tracker.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- required "serviceAccount.name must be set when serviceAccount.create is false" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/deployment-tracker/templates/clusterrole.yaml
+++ b/deploy/charts/deployment-tracker/templates/clusterrole.yaml
@@ -25,10 +25,3 @@ rules:
       - replicasets
     verbs:
       - get
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - jobs
-    verbs:
-      - get

--- a/deploy/charts/deployment-tracker/templates/clusterrole.yaml
+++ b/deploy/charts/deployment-tracker/templates/clusterrole.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "deployment-tracker.fullname" . }}
+  labels:
+    {{- include "deployment-tracker.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get

--- a/deploy/charts/deployment-tracker/templates/clusterrolebinding.yaml
+++ b/deploy/charts/deployment-tracker/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "deployment-tracker.fullname" . }}
+  labels:
+    {{- include "deployment-tracker.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "deployment-tracker.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "deployment-tracker.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/deployment-tracker/templates/deployment.yaml
+++ b/deploy/charts/deployment-tracker/templates/deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "deployment-tracker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "deployment-tracker.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "deployment-tracker.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "deployment-tracker.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "deployment-tracker.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- $args := list }}
+          {{- if .Values.config.namespace }}
+          {{- $args = append $args (printf "-namespace=%s" .Values.config.namespace) }}
+          {{- end }}
+          {{- if .Values.config.excludeNamespaces }}
+          {{- $args = append $args (printf "-exclude-namespaces=%s" .Values.config.excludeNamespaces) }}
+          {{- end }}
+          {{- if ne (int .Values.config.workers) 2 }}
+          {{- $args = append $args (printf "-workers=%d" (int .Values.config.workers)) }}
+          {{- end }}
+          {{- if ne (int .Values.config.metricsPort) 9090 }}
+          {{- $args = append $args (printf "-metrics-port=%s" (toString .Values.config.metricsPort)) }}
+          {{- end }}
+          {{- if $args }}
+          args:
+            {{- range $args }}
+            - {{ . }}
+            {{- end }}
+          {{- end }}
+          env:
+            - name: GITHUB_ORG
+              value: {{ required "config.org is required" .Values.config.org | quote }}
+            - name: LOGICAL_ENVIRONMENT
+              value: {{ required "config.logicalEnvironment is required" .Values.config.logicalEnvironment | quote }}
+            - name: CLUSTER
+              value: {{ required "config.cluster is required" .Values.config.cluster | quote }}
+            {{- if .Values.config.physicalEnvironment }}
+            - name: PHYSICAL_ENVIRONMENT
+              value: {{ .Values.config.physicalEnvironment | quote }}
+            {{- end }}
+            - name: BASE_URL
+              value: {{ .Values.config.baseUrl | quote }}
+            - name: DN_TEMPLATE
+              value: {{ .Values.config.dnTemplate | quote }}
+            {{- if .Values.auth.apiToken }}
+            - name: API_TOKEN
+              value: {{ .Values.auth.apiToken | quote }}
+            {{- else if .Values.auth.apiTokenSecret }}
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.apiTokenSecret }}
+                  key: token
+            {{- end }}
+            {{- if .Values.auth.githubApp.appId }}
+            - name: GH_APP_ID
+              value: {{ .Values.auth.githubApp.appId | quote }}
+            {{- end }}
+            {{- if .Values.auth.githubApp.installId }}
+            - name: GH_INSTALL_ID
+              value: {{ .Values.auth.githubApp.installId | quote }}
+            {{- end }}
+            {{- if .Values.auth.githubApp.privateKey }}
+            - name: GH_APP_PRIVATE_KEY
+              value: {{ .Values.auth.githubApp.privateKey | quote }}
+            {{- else if .Values.auth.githubApp.privateKeySecret }}
+            - name: GH_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.githubApp.privateKeySecret }}
+                  key: private-key
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.config.metricsPort }}
+              protocol: TCP
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/deployment-tracker/templates/deployment.yaml
+++ b/deploy/charts/deployment-tracker/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.config.namespace .Values.config.excludeNamespaces }}
+{{- fail "config.namespace and config.excludeNamespaces are mutually exclusive and cannot both be set" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/charts/deployment-tracker/templates/service.yaml
+++ b/deploy/charts/deployment-tracker/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deployment-tracker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "deployment-tracker.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: metrics
+      port: {{ .Values.service.port }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "deployment-tracker.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/charts/deployment-tracker/templates/serviceaccount.yaml
+++ b/deploy/charts/deployment-tracker/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "deployment-tracker.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "deployment-tracker.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/deployment-tracker/values.yaml
+++ b/deploy/charts/deployment-tracker/values.yaml
@@ -1,0 +1,107 @@
+# Number of controller replicas
+replicaCount: 1
+
+image:
+  repository: ghcr.io/github/deployment-tracker
+  # Overrides the image tag (default is the chart appVersion)
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Controller configuration
+config:
+  # GitHub organization name (required)
+  org: ""
+  # Logical environment name (required)
+  logicalEnvironment: ""
+  # Cluster name (required)
+  cluster: ""
+  # Physical environment name
+  physicalEnvironment: ""
+  # API base URL
+  baseUrl: "api.github.com"
+  # Deployment name template
+  dnTemplate: "{{namespace}}/{{deploymentName}}/{{containerName}}"
+  # Namespace to monitor (empty for all namespaces)
+  namespace: ""
+  # Comma-separated list of namespaces to exclude from monitoring
+  excludeNamespaces: ""
+  # Number of worker goroutines
+  workers: 2
+  # Port for Prometheus metrics
+  metricsPort: 9090
+
+# Authentication configuration
+auth:
+  # Option 1: API token (plaintext value, use apiTokenSecret for production)
+  apiToken: ""
+  # Option 2: Reference to an existing Kubernetes Secret containing the API token
+  # The secret must have a key named "token"
+  apiTokenSecret: ""
+  # Option 3: GitHub App authentication
+  githubApp:
+    appId: ""
+    installId: ""
+    # Base64-encoded private key (use privateKeySecret for production)
+    privateKey: ""
+    # Reference to an existing Kubernetes Secret containing the GitHub App private key
+    # The secret must have a key named "private-key" with the base64-encoded key
+    privateKeySecret: ""
+
+serviceAccount:
+  # Whether to create a ServiceAccount
+  create: true
+  # Annotations to add to the ServiceAccount
+  annotations: {}
+  # The name of the ServiceAccount to use
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+service:
+  # Whether to create a Service for metrics
+  enabled: true
+  type: ClusterIP
+  port: 9090
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 1024Mi
+  limits:
+    cpu: 200m
+    memory: 2048Mi
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+
+# Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /metrics
+    port: metrics
+  initialDelaySeconds: 120
+
+# Lifecycle hooks
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - sleep
+        - "5"
+
+podAnnotations: {}
+podLabels: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary

Adds a Helm chart to make it easy for customers to install the deployment-tracker controller. The chart is co-located in the repo under `deploy/charts/deployment-tracker/`, following the pattern used by [cert-manager](https://github.com/cert-manager/cert-manager/tree/master/deploy/charts) and [external-secrets](https://github.com/external-secrets/external-secrets/tree/main/deploy/charts).

## What's included

### Helm chart (`deploy/charts/deployment-tracker/`)

- **`Chart.yaml`** — chart metadata (apiVersion v2, type application)
- **`values.yaml`** — all configurable options with sensible defaults:
  - Image config (`ghcr.io/github/deployment-tracker`)
  - Controller config (org, logicalEnvironment, cluster, baseUrl, dnTemplate, namespace filtering, workers, metricsPort)
  - Auth — supports both API token and GitHub App, with inline values or references to existing K8s Secrets
  - Resources, security context, readiness probe, lifecycle hooks (matching internal production config)
  - Service, ServiceAccount, pod annotations, node scheduling
- **Templates**: ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, Service, NOTES.txt
- **`_helpers.tpl`** — standard Helm name/label/selector helpers
- **`README.md`** — configuration docs with install examples and auth setup

### CI workflow updates

- **`release.yaml`** — on tag push, now also packages and pushes the Helm chart as an OCI artifact to `oci://ghcr.io/github/charts` alongside the container image build
- **`build.yml`** — new `helm-lint` job runs `helm lint` and `helm template` validation on PRs and pushes to main

## Install

```bash
helm install deployment-tracker \
  oci://ghcr.io/github/charts/deployment-tracker \
  --namespace deployment-tracker --create-namespace \
  --set config.org=my-org \
  --set config.logicalEnvironment=production \
  --set config.cluster=my-cluster \
  --set auth.apiTokenSecret=my-secret
```

## Design decisions

- **Chart in-repo** (not a separate repo) — chart and controller are tightly coupled; co-location allows atomic changes and simpler CI
- **OCI publishing to ghcr.io** — modern Helm best practice, no `index.yaml` maintenance, co-locates chart with container image
- **Auth via Secret references** — recommended for production; inline values supported for dev/testing
- **Required values enforced** — `config.org`, `config.logicalEnvironment`, and `config.cluster` are validated at template time