### PR TITLE
Add Deployment informer to replace direct API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ which includes:
 
 - **Namespace**: `deployment-tracker`
 - **ServiceAccount**: Identity for the controller pod
-- **ClusterRole**: Minimal permissions (`get`, `list`, `watch` on pods; `get` on other supported objects)
+- **ClusterRole**: Minimal permissions (`get`, `list`, `watch` on pods and deployments; `get` on other supported objects)
 - **ClusterRoleBinding**: Binds the ServiceAccount to the ClusterRole
 - **Deployment**: Runs the controller with security hardening
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The controller requires the following minimum permissions:
 | API Group | Resource | Verbs |
 |-----------|----------|-------|
 | `""` (core) | `pods` | `get`, `list`, `watch` |
+| `apps` | `deployments` | `get`, `list`, `watch` |
+| `apps` | `replicasets` | `get` |
 
 If you only need to monitor a single namespace, you can modify the manifest to use a `Role` and `RoleBinding` instead of `ClusterRole` and `ClusterRoleBinding` for more restricted permissions.
 

--- a/deploy/charts/deployment-tracker/templates/clusterrole.yaml
+++ b/deploy/charts/deployment-tracker/templates/clusterrole.yaml
@@ -19,6 +19,8 @@ rules:
       - deployments
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
       - apps
     resources:

--- a/deploy/manifest.yaml
+++ b/deploy/manifest.yaml
@@ -19,7 +19,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["replicasets"]
     verbs: ["get"]

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	appslisters "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -64,6 +65,8 @@ type Controller struct {
 	clientset          kubernetes.Interface
 	metadataAggregator podMetadataAggregator
 	podInformer        cache.SharedIndexInformer
+	deploymentInformer cache.SharedIndexInformer
+	deploymentLister   appslisters.DeploymentLister
 	workqueue          workqueue.TypedRateLimitingInterface[PodEvent]
 	apiClient          deploymentRecordPoster
 	cfg                *Config
@@ -82,6 +85,8 @@ func New(clientset kubernetes.Interface, metadataAggregator podMetadataAggregato
 	factory := createInformerFactory(clientset, namespace, excludeNamespaces)
 
 	podInformer := factory.Core().V1().Pods().Informer()
+	deploymentInformer := factory.Apps().V1().Deployments().Informer()
+	deploymentLister := factory.Apps().V1().Deployments().Lister()
 
 	// Create work queue with rate limiting
 	queue := workqueue.NewTypedRateLimitingQueue(
@@ -117,6 +122,8 @@ func New(clientset kubernetes.Interface, metadataAggregator podMetadataAggregato
 		clientset:           clientset,
 		metadataAggregator:  metadataAggregator,
 		podInformer:         podInformer,
+		deploymentInformer:  deploymentInformer,
+		deploymentLister:    deploymentLister,
 		workqueue:           queue,
 		apiClient:           apiClient,
 		cfg:                 cfg,
@@ -237,14 +244,15 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	defer runtime.HandleCrash()
 	defer c.workqueue.ShutDown()
 
-	slog.Info("Starting pod informer")
+	slog.Info("Starting informers")
 
-	// Start the informer
+	// Start the informers
 	go c.podInformer.Run(ctx.Done())
+	go c.deploymentInformer.Run(ctx.Done())
 
-	// Wait for the cache to be synced
-	slog.Info("Waiting for informer cache to sync")
-	if !cache.WaitForCacheSync(ctx.Done(), c.podInformer.HasSynced) {
+	// Wait for the caches to be synced
+	slog.Info("Waiting for informer caches to sync")
+	if !cache.WaitForCacheSync(ctx.Done(), c.podInformer.HasSynced, c.deploymentInformer.HasSynced) {
 		return errors.New("timed out waiting for caches to sync")
 	}
 
@@ -327,7 +335,7 @@ func (c *Controller) processEvent(ctx context.Context, event PodEvent) error {
 		// the referenced image digest to the newly observed (via
 		// the create event).
 		deploymentName := getDeploymentName(pod)
-		if deploymentName != "" && c.deploymentExists(ctx, pod.Namespace, deploymentName) {
+		if deploymentName != "" && c.deploymentExists(pod.Namespace, deploymentName) {
 			slog.Debug("Deployment still exists, skipping pod delete (scale down)",
 				"namespace", pod.Namespace,
 				"deployment", deploymentName,
@@ -390,16 +398,14 @@ func (c *Controller) processEvent(ctx context.Context, event PodEvent) error {
 	return lastErr
 }
 
-// deploymentExists checks if a deployment exists in the cluster.
-func (c *Controller) deploymentExists(ctx context.Context, namespace, name string) bool {
-	_, err := c.clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+// deploymentExists checks if a deployment exists in the local informer cache.
+func (c *Controller) deploymentExists(namespace, name string) bool {
+	_, err := c.deploymentLister.Deployments(namespace).Get(name)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false
 		}
-		// On error, assume it exists to be safe
-		// (avoid false decommissions)
-		slog.Warn("Failed to check if deployment exists, assuming it does",
+		slog.Warn("Failed to check if deployment exists in cache, assuming it does",
 			"namespace", namespace,
 			"deployment", name,
 			"error", err,

--- a/internal/controller/controller_integration_test.go
+++ b/internal/controller/controller_integration_test.go
@@ -119,7 +119,7 @@ func setup(t *testing.T, onlyNamespace string, excludeNamespaces string) (*kuber
 	go func() {
 		_ = ctrl.Run(ctx, 1)
 	}()
-	if !cache.WaitForCacheSync(ctx.Done(), ctrl.podInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), ctrl.podInformer.HasSynced, ctrl.deploymentInformer.HasSynced) {
 		t.Fatal("timed out waiting for informer cache to sync")
 	}
 


### PR DESCRIPTION
## What

Adds a Deployment informer alongside the existing Pod informer so that `deploymentExists()` checks a local in-memory cache instead of making a live `GET` call to the Kubernetes API server.

## Why

Every pod delete event triggers a `clientset.AppsV1().Deployments().Get()` call to determine if the parent deployment still exists (to distinguish scale-downs from true decommissions). When a deployment with N pods is deleted, this results in N synchronous API server round-trips checking the same deployment.

## Changes

- **`internal/controller/controller.go`** — Added `deploymentInformer` and `deploymentLister` fields to `Controller`. The deployment informer is created from the same `SharedInformerFactory` used for the pod informer. `deploymentExists()` now reads from the lister cache (in-memory) instead of calling the API server.
- **`internal/controller/controller_integration_test.go`** — Updated `setup()` to wait for both informer caches to sync.
- **`deploy/manifest.yaml`** — Added `list` and `watch` verbs to the deployments RBAC rule.
- **`deploy/charts/deployment-tracker/templates/clusterrole.yaml`** — Same RBAC update in the Helm chart.
- **`README.md`** — Updated the RBAC permissions table.

## Tradeoffs

| | Before (API GET) | After (Informer Cache) |
|---|---|---|
| Latency per check | Network round-trip | In-memory (~ns) |
| API server load | 1 GET per pod delete | Single shared WATCH stream |
| Memory | None | Caches Deployment objects (small relative to already-cached Pods) |
| RBAC | `get` on deployments | `get`, `list`, `watch` on deployments |
| Staleness | None | Negligible (WATCH delivers events within ms) |

Resolves https://github.com/github/package-security/issues/4179