### PR TITLE
Set return_records to false

### DIFF
--- a/pkg/deploymentrecord/client.go
+++ b/pkg/deploymentrecord/client.go
@@ -189,7 +189,7 @@ func (c *Client) PostOne(ctx context.Context, record *DeploymentRecord) error {
 
 	url := fmt.Sprintf("%s/orgs/%s/artifacts/metadata/deployment-record", c.baseURL, c.org)
 
-	body, err := json.Marshal(record)
+	body, err := buildRequestBody(record)
 	if err != nil {
 		return fmt.Errorf("failed to marshal record: %w", err)
 	}
@@ -396,6 +396,18 @@ func parseRateLimitDelay(resp *http.Response) time.Duration {
 	default:
 		return time.Minute
 	}
+}
+
+// buildRequestBody adds return_records=false to a deployment record request body
+// which results in a minimal response payload.
+func buildRequestBody(record *DeploymentRecord) ([]byte, error) {
+	return json.Marshal(struct {
+		DeploymentRecord
+		ReturnRecords bool `json:"return_records"`
+	}{
+		DeploymentRecord: *record,
+		ReturnRecords:    false,
+	})
 }
 
 func waitForBackoff(ctx context.Context, attempt int) error {

--- a/pkg/deploymentrecord/client_test.go
+++ b/pkg/deploymentrecord/client_test.go
@@ -1,8 +1,10 @@
 package deploymentrecord
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -592,6 +594,13 @@ func TestPostOneSendsCorrectRequest(t *testing.T) {
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
 			t.Errorf("Authorization = %s, want Bearer test-token", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal("unable to read request body")
+		}
+		if !bytes.Contains(body, []byte("\"return_records\":false")) {
+			t.Error("expected '\"return_records\":false' in the request body")
 		}
 		w.WriteHeader(http.StatusOK)
 	}))


### PR DESCRIPTION
This changes sets return_records to false when creating deployment records. This will reduce bandwidth as deployment tracker does not use the response body content from creating deployment records. 

https://docs.github.com/en/rest/orgs/artifact-metadata?apiVersion=2026-03-10#create-an-artifact-deployment-record