### PR TITLE
Dependabot and Workflow Hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,8 +21,17 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    env:
+      GOFLAGS: "-mod=readonly"
     permissions:
       contents: read
     steps:
@@ -30,6 +32,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      GOFLAGS: "-mod=readonly"
     permissions:
       contents: read
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
   golangci-lint:
     name: lint
     runs-on: ubuntu-latest
+    env:
+      GOFLAGS: "-mod=readonly"
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
This changes adds the following changes to increase security posture towards supply chain style attacks:
- Add three day cooldown to Dependabot updates
- Be consistent in Dependabot grouping
- Add GOFLAG `-mod=readonly`