### PR TITLE
fix: increase http client timeout

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -39,6 +39,11 @@ const (
 	// informerSyncTimeoutDuration is the maximum duration of time allowed
 	// for the informers to sync to prevent the controller from hanging indefinitely.
 	informerSyncTimeoutDuration = 60 * time.Second
+
+	// deploymentRecordClientTimeoutSeconds sets the HTTP timeout for calls to the
+	// deployment record API. The timeout is generous to accommodate longer running
+	// calls like posting a cluster job.
+	deploymentRecordClientTimeoutSeconds = 30
 )
 
 type ttlCache interface {
@@ -133,6 +138,7 @@ func New(clientset kubernetes.Interface, metadataAggregator podMetadataAggregato
 			cfg.GHAppPrivateKeyPath,
 		))
 	}
+	clientOpts = append(clientOpts, deploymentrecord.WithTimeout(deploymentRecordClientTimeoutSeconds))
 
 	apiClient, err := deploymentrecord.NewClient(
 		cfg.BaseURL,


### PR DESCRIPTION
- Increases the global timeout for the http client, as posting a job for over 1000 deployments can easily take more than the 5 second default timer
- There is a small tradeoff here that a hung PostOne or Get call could now occupy a worker for the full 30 seconds, but the risk and downside of that are both pretty low in practice. We can optionally move to per-request timeouts later, but that's a bit more involved.