### PR TITLE
adjust logging around cluster job

### DIFF
--- a/internal/controller/reporting.go
+++ b/internal/controller/reporting.go
@@ -215,6 +215,7 @@ func (c *Controller) makeSyncRecords(ctx context.Context, syncClusterPods []any)
 	// During a rollout the same deployment_name can appear with multiple digests
 	// (old and new pods running at once), so we must collapse to a single digest per workload and
 	// container name. We pick the newest running pod so the snapshot reflects the rollout target.
+	slog.Info("making sync records...")
 	winners := make(map[string]syncCandidate)
 	for _, p := range syncClusterPods {
 		pod, ok := p.(*corev1.Pod)
@@ -271,7 +272,7 @@ func (c *Controller) makeSyncRecords(ctx context.Context, syncClusterPods []any)
 			// Keep the newest running pod's digest and log the decision so the
 			// rollout is visible.
 			if isPreferredSyncPod(pod, existing.pod) {
-				slog.Info("Multiple digests observed for deployment_name during sync, choosing preferred pod",
+				slog.Debug("Multiple digests observed for deployment_name during sync, choosing preferred pod",
 					"deployment_name", dn,
 					"chosen_pod", pod.Name,
 					"chosen_digest", digest,
@@ -280,7 +281,7 @@ func (c *Controller) makeSyncRecords(ctx context.Context, syncClusterPods []any)
 				)
 				winners[dn] = syncCandidate{pod: pod, container: container, wlName: wl.Name}
 			} else {
-				slog.Info("Multiple digests observed for deployment_name during sync, keeping preferred pod",
+				slog.Debug("Multiple digests observed for deployment_name during sync, keeping preferred pod",
 					"deployment_name", dn,
 					"kept_pod", existing.pod.Name,
 					"kept_digest", existingDigest,

--- a/pkg/deploymentrecord/client.go
+++ b/pkg/deploymentrecord/client.go
@@ -262,6 +262,7 @@ func (c *Client) PostOne(ctx context.Context, record *Record) error {
 // Returns the job response (including job ID) and any authorization errors
 // for rejected deployments.
 func (c *Client) CreateClusterJob(ctx context.Context, records []*Record, cluster string) (*JobResponse, error) {
+	slog.Info("starting cluster job", "record_count", len(records))
 	if len(records) == 0 {
 		return nil, errors.New("records cannot be empty")
 	}
@@ -339,6 +340,11 @@ func (c *Client) WaitForClusterJob(ctx context.Context, cluster string, jobID in
 		}
 		if status.Status == "completed" || status.Status == "failed" {
 			return status, nil
+		} else {
+			slog.Info("waiting for cluster job completion",
+				"status", status,
+				"attempt", attempt,
+			)
 		}
 
 		delay := time.Duration(math.Min(

--- a/pkg/deploymentrecord/client.go
+++ b/pkg/deploymentrecord/client.go
@@ -340,12 +340,11 @@ func (c *Client) WaitForClusterJob(ctx context.Context, cluster string, jobID in
 		}
 		if status.Status == "completed" || status.Status == "failed" {
 			return status, nil
-		} else {
-			slog.Info("waiting for cluster job completion",
-				"status", status,
-				"attempt", attempt,
-			)
 		}
+		slog.Info("waiting for cluster job completion",
+			"status", status,
+			"attempt", attempt,
+		)
 
 		delay := time.Duration(math.Min(
 			float64(initialDelay)*math.Pow(2, float64(attempt)),

--- a/pkg/deploymentrecord/client.go
+++ b/pkg/deploymentrecord/client.go
@@ -342,7 +342,8 @@ func (c *Client) WaitForClusterJob(ctx context.Context, cluster string, jobID in
 			return status, nil
 		}
 		slog.Info("waiting for cluster job completion",
-			"status", status,
+			"job_id", jobID,
+			"status", status.Status,
 			"attempt", attempt,
 		)
 


### PR DESCRIPTION
adjust logging around cluster job

- add logs to inform on status of a cluster job
- set "Multiple digests observed" logs from Info to Debug to reduce noise