### PR TITLE
Prepare for v1.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,8 +67,9 @@ jobs:
       - name: Update chart version
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
+          IMAGE_TAG=${GITHUB_REF#refs/tags/}
           sed -i "s/^version:.*/version: ${VERSION}/" deploy/charts/deployment-tracker/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" deploy/charts/deployment-tracker/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${IMAGE_TAG}\"/" deploy/charts/deployment-tracker/Chart.yaml
 
       - name: Package Helm chart
         run: helm package deploy/charts/deployment-tracker

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Deployment Tracker
 
-> [!CAUTION]
-> This project is in an early preview state and contains experimental
-> code. It is under active development and not ready for production
-> use. Breaking changes are likely, and stability or security is not
-> guaranteed. Use at your own risk.
-
 A Kubernetes controller that monitors pod lifecycles and uploads
 deployment records to GitHub's artifact metadata API.
 

--- a/deploy/charts/deployment-tracker/Chart.yaml
+++ b/deploy/charts/deployment-tracker/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: deployment-tracker
 description: A Kubernetes controller that monitors pod lifecycles and uploads deployment records to GitHub's artifact metadata API
 type: application
-version: 0.0.0
-appVersion: "0.0.0"
+version: 1.0.0
+appVersion: "v1.0.0"
 kubeVersion: ">= 1.19.0-0"
 keywords:
   - kubernetes

--- a/deploy/charts/deployment-tracker/README.md
+++ b/deploy/charts/deployment-tracker/README.md
@@ -64,6 +64,7 @@ At least one authentication method must be configured (see
 | `config.dnTemplate` | Deployment name template | `{{namespace}}/{{deploymentName}}/{{containerName}}` |
 | `config.namespace` | Namespace to monitor (empty for all) | `""` |
 | `config.excludeNamespaces` | Namespaces to exclude (comma-separated) | `""` |
+| `config.bulkClusterSync` | Bulk-sync cluster state at startup | `true` |
 | `config.workers` | Number of worker goroutines | `2` |
 | `config.metricsPort` | Port for Prometheus metrics | `9090` |
 

--- a/deploy/charts/deployment-tracker/templates/deployment.yaml
+++ b/deploy/charts/deployment-tracker/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: {{ .Values.config.baseUrl | quote }}
             - name: DN_TEMPLATE
               value: {{ .Values.config.dnTemplate | quote }}
+            - name: BULK_CLUSTER_SYNC
+              value: {{ .Values.config.bulkClusterSync | quote }}
             {{- if .Values.auth.apiToken }}
             - name: API_TOKEN
               value: {{ .Values.auth.apiToken | quote }}

--- a/deploy/charts/deployment-tracker/values.yaml
+++ b/deploy/charts/deployment-tracker/values.yaml
@@ -30,6 +30,8 @@ config:
   namespace: ""
   # Comma-separated list of namespaces to exclude from monitoring
   excludeNamespaces: ""
+  # Bulk-sync cluster state when the controller starts
+  bulkClusterSync: true
   # Number of worker goroutines
   workers: 2
   # Port for Prometheus metrics


### PR DESCRIPTION
This PR is to prepare for cutting a v1.0.0 tag

- Removes "experimental" note
- Adjusts release.yaml for helm charts
- Adds `BULK_CLUSTER_SYNC` to helm chart